### PR TITLE
Fix JSONDecodeError exceptions

### DIFF
--- a/pyvera/subscribe.py
+++ b/pyvera/subscribe.py
@@ -132,6 +132,10 @@ class SubscriptionRegistry(object):
                 LOG.info("Could not contact Vera - will retry in %ss",
                          SUBSCRIPTION_RETRY)
                 time.sleep(SUBSCRIPTION_RETRY)
+            except json.decoder.JSONDecodeError:
+                LOG.exception("Response was malfomed - will retry in %ss",
+                         SUBSCRIPTION_RETRY)
+                time.sleep(SUBSCRIPTION_RETRY)
             except Exception as ex:
                 LOG.exception("Vera thread exception %s", ex)
                 raise


### PR DESCRIPTION
I use pyvera in my instance of Home Assistant (HA). I have consistently noticed that sometime between one and two days after starting HA, pyvera's subscription/polling feature stops working due to a single JSONDecodeError exception. This pull request will safely handle JSONDecodeError exceptions and allow polling to continue.

For reference, the stack trace always looks like this:
```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/pyvera/subscribe.py", line 118, in _run_poll_server
    controller.get_changed_devices(timestamp))
  File "/usr/local/lib/python3.5/site-packages/pyvera/__init__.py", line 218, in get_changed_devices
    result = self.data_request(payload, TIMEOUT*3).json()
  File "/usr/local/lib/python3.5/site-packages/requests/models.py", line 866, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/__init__.py", line 319, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This works perfectly for me, and should hopefully help out anyone else who may or may not be experiencing this problem.